### PR TITLE
Make Attachments return the attachment type

### DIFF
--- a/src/Command/OptionBuilder.ts
+++ b/src/Command/OptionBuilder.ts
@@ -8,6 +8,7 @@ import {
   InteractionOptions,
   AnyGuildTextChannel,
   AnyTextChannelWithoutGroup,
+  Attachment,
 } from "oceanic.js";
 import type { BaseCommandData } from "./BaseCommand";
 
@@ -135,7 +136,7 @@ export type OptionArgType<O extends BaseCommandData, P extends OptionKV> = {
     : P[K]["type"] extends Constants.ApplicationCommandOptionTypes.NUMBER
     ? number
     : P[K]["type"] extends Constants.ApplicationCommandOptionTypes.ATTACHMENT
-    ? string
+    ? Attachment
     : never;
 };
 
@@ -307,12 +308,16 @@ export async function ConvertInteractionOptions<
             ? interaction.data.resolved.roles.get(option.value)
             : null;
           break;
+        case Constants.ApplicationCommandOptionTypes.ATTACHMENT:
+          options[option.name] = interaction.data.resolved.attachments.get(
+            option.value
+          );
+          break;
         default:
           options[option.name] = option.value;
           break;
       }
     }
   }
-
   return options as OptionArgType<O, P>;
 }


### PR DESCRIPTION
I was trying to use the Attachment option type and instead of returning anything useful it returned the id of the image. This makes it return the actual attachment type instead of a string.

Hope I did this right, its my first time actually contributing to a project.